### PR TITLE
Removed noScale limit type; autoScale and manualScale now work for all data types

### DIFF
--- a/PY_NTNDA_Viewer/NTNDA_Viewer.py
+++ b/PY_NTNDA_Viewer/NTNDA_Viewer.py
@@ -178,14 +178,11 @@ class NTNDA_Viewer(QWidget) :
         
         showbox = QHBoxLayout()
         groupbox=QGroupBox('scaleType')
-        self.noScaleButton = QRadioButton('noScale')
-        self.noScaleButton.setChecked(True)
-        self.noScaleButton.toggled.connect(self.noScaleEvent)
         self.autoScaleButton = QRadioButton('autoScale')
         self.autoScaleButton.toggled.connect(self.autoScaleEvent)
+        self.autoScaleButton.setChecked(True)
         self.manualScaleButton = QRadioButton('manualScale')
         self.manualScaleButton.toggled.connect(self.manualScaleEvent)
-        showbox.addWidget(self.noScaleButton)
         showbox.addWidget(self.autoScaleButton)
         showbox.addWidget(self.manualScaleButton)
         groupbox.setLayout(showbox)
@@ -300,8 +297,6 @@ class NTNDA_Viewer(QWidget) :
         if self.isClosed : return
         if type(self.imageDict["image"])==type(None) : return
         try :
-            if self.limitType>0 :
-                self.scaleLimits()
             self.imageDisplay.display(self.imageDict["image"])
         except Exception as error:
             self.statusText.setText(str(error))    
@@ -322,16 +317,12 @@ class NTNDA_Viewer(QWidget) :
         self.statusText.setText('')
         self.statusText.setStyleSheet("background-color:white")
         
-    def noScaleEvent(self) :  
+    def autoScaleEvent(self) :  
         self.limitType = 0
         self.display()
          
-    def autoScaleEvent(self) :  
-        self.limitType = 1
-        self.display()
-         
     def manualScaleEvent(self) :  
-        self.limitType = 2
+        self.limitType = 1
         self.display()
         
     def showLimitsEvent(self) :  
@@ -373,26 +364,6 @@ class NTNDA_Viewer(QWidget) :
             self.display()
         except Exception as error:
             self.statusText.setText(str(error))
-            
-    def scaleLimits(self) :
-        image = self.imageDict["image"]
-        dtype = image.dtype
-        if self.limitType== 0 :
-            return
-        elif self.limitType== 1 :
-           start = self.limits[0]
-           end = self.limits[1]
-        else :
-            start = self.minLimitText.text()
-            end = self.maxLimitText.text()
-        xp = (float(start),float(end))
-        if dtype==np.uint8 :
-            fp = (0.0,255.0)
-        else :
-            fp = (0.0,65535)
-        image = np.interp(image,xp,fp)
-        image = image.astype(dtype)
-        self.imageDict["image"] = image   
     
     def channelNameEvent(self) :
         try:
@@ -544,48 +515,22 @@ class NTNDA_Viewer(QWidget) :
         if ndim!=2 and ndim!=3 :
             raise Exception('ndim not 2 or 3')
             return
-        dataMin = int(np.min(data))
-        dataMax = int(np.max(data))
+        dtype = data.dtype
+        dataMin = np.min(data)
+        dataMax = np.max(data)
+        if self.limitType== 0 :
+            displayMin = dataMin
+            displayMax = dataMax
+            self.limits = (dataMin, dataMax)
+        else :
+            displayMin = float(self.minLimitText.text())
+            displayMax = float(self.maxLimitText.text())
         if self.showLimits :
             self.channelLimitsText.setText(str((dataMin,dataMax)))
-        dtype = data.dtype
-        if dtype==np.int8 :
-            xp = (-128.0,127.0)
-            fp = (0.0,255.0)
-            data = np.interp(data,xp,fp)
-            data = data.astype(np.uint8)
-        elif dtype==np.uint8 :
-            pass
-        elif dtype==np.int16 :
-            xp = (-32768.0,32767.0)
-            fp = (0.0,255.0)
-            data = np.interp(data,xp,fp)
-            data = data.astype(np.uint8)
-        elif dtype==np.uint16 :
-            xp = (0.0,65535.0)
-            fp = (0.0,255.0)
-            data = np.interp(data,xp,fp)
-            data = data.astype(np.uint8)
-        elif dtype==np.int32 :
-            xp = (-2147483648,2147483647.0)
-            fp = (0.0,255.0)
-            data = np.interp(data,xp,fp)
-            data = data.astype(np.uint8)       
-        elif dtype==np.uint32 :
-            xp = (0.0,4294967295.0)
-            fp = (0.0,255.0)
-            data = np.interp(data,xp,fp)
-            data = data.astype(np.uint8)
-        else :
-            xp = (float(dataMin),float(dataMax))
-            fp = (0.0,255.0)
-            data = np.interp(data,xp,fp)
-            data = data.astype(np.uint8)
+        xp = (displayMin, displayMax)
+        fp = (0.0, 255.0)
+        data = (np.interp(data,xp,fp)).astype(np.uint8)
         
-        if self.limitType==1:
-            self.limits = (int(np.min(data)),int(np.max(data)))
-        if self.showLimits :
-            self.imageLimitsText.setText(str((int(np.min(data)),int(np.max(data)))))       
         if ndim ==2 :
             nx = dimArray[0]["size"]
             ny = dimArray[1]["size"]


### PR DESCRIPTION
I got rid of the noScale option, I don't think it is useful.

The code is now much simpler.  The scaleLimits function is removed.

The scaling is done in dataToImage and works for all data types in both autoScale and manualScale modes.

It is more efficient.

What does not work is to rescale a static image when it is stopped.  But I think that is easy to add.  Right now we are replacing "data" in dataToImage.  Instead we want to keep the original unscaled array and the new scaled array.

The next step is to run the scaled array through a lookup table that returns an RGB image, and display that.